### PR TITLE
fix(whisper-rocm): pin yt-dlp to 2026.03.17 (closes #48)

### DIFF
--- a/docker/whisper-rocm.Dockerfile
+++ b/docker/whisper-rocm.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 # yt-dlp extracts audio, whisper transcribes, ffmpeg handles format conversion
 RUN pip install --no-cache-dir \
     openai-whisper \
-    yt-dlp \
+    "yt-dlp==2026.03.17" \
     && apt-get update \
     && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
root cause: unpinned yt-dlp pip install caused version drift and transcription failures

what changed: docker/whisper-rocm.Dockerfile — `yt-dlp` → `"yt-dlp==2026.03.17"`

validation: hcom ran cold rebuild locally, verified `yt-dlp --version` inside fresh image. kerouac confirmed 2026.03.17 is latest stable release (github.com/yt-dlp/yt-dlp/releases/tag/2026.03.17)

impact: unblocks 17 failed transcription runs since 2026-04-10

operational note: no rootfs or compose changes needed on consumer side — image rebuild handles it

Closes #48

originating agent: hs-shannon-theseus-hcom-code-validator