### PR TITLE
fix(vision): pin rocm/pytorch to rocm6.4.4_torch2.6.0 (Instella-VL-1B regression)

### DIFF
--- a/docker/vision-rocm.Dockerfile
+++ b/docker/vision-rocm.Dockerfile
@@ -1,6 +1,19 @@
-FROM rocm/pytorch:latest
+# Pin to a known-stable rocm/pytorch tag.
+# rocm/pytorch:latest is a floating tag — when AMD published rocm7.2.x + torch
+# 2.10 (~2026-05) the auto-pulled latest broke Instella-VL-1B model load on
+# RX 6700 XT (gfx1031) with `HIP error: out of memory` at .to("cuda") even
+# with the full 12GB VRAM free. The regression is below the application
+# layer (single-tensor allocation fails), not in our code or env vars.
+# rocm6.4.4 + torch 2.6.0 is the last known-stable combination for this card.
+FROM rocm/pytorch:rocm6.4.4_ubuntu22.04_py3.10_pytorch_release_2.6.0
 
 WORKDIR /app
+
+# Add render (993) and video (44) groups to match host GIDs required for ROCm GPU access.
+# Docker --group-add resolves names against the container's /etc/group; without these
+# entries the container launch fails with "no matching entries in group file".
+RUN groupadd -g 993 render 2>/dev/null || true && \
+    groupadd -g 44 video 2>/dev/null || true
 
 # transformers + vision deps — no model pre-download; HF cache is a volume mount
 # Pin to transformers==4.49.0 (AMD official supported version for Instella-VL-1B).


### PR DESCRIPTION
## Regression symptom

`rocm/pytorch:latest` floated to rocm7.2.3 + torch 2.10 in late 2026-05 and broke Instella-VL-1B model load on RX 6700 XT (gfx1031). A single-tensor `.to('cuda')` OOMs with full 12 GB VRAM free — the regression is below the application layer (HIP allocator).

## What was tried (did not fix)

- `PYTORCH_HIP_ALLOC_CONF` tuning (expandable segments, garbage collection threshold)
- `HSA_OVERRIDE_GFX_VERSION` swap (10.3.0 → 11.0.0)
- `device_map="auto"` + `low_cpu_mem_usage=True` + explicit `max_memory` cap

None resolved the OOM; the allocator regression is in the base image itself.

## Verification

Rebuilt against pinned base `rocm/pytorch:rocm6.4.4_ubuntu22.04_py3.12_pytorch_release_2.6.0` on rocm-aibox (2026-05-29). Instella-VL-1B loads cleanly and processes 17 test frames end-to-end without OOM.

## Follow-up note (not addressed here)

ollama's minicpm-v on the same 17 frames produced ~4× more words/frame and materially more accurate slide content (Instella consistently described dark conference slides as "white background black border"). Quality comparison deserves a separate investigation.